### PR TITLE
Fix sort not working

### DIFF
--- a/lib/chetmac/Airpress.php
+++ b/lib/chetmac/Airpress.php
@@ -213,7 +213,7 @@ class Airpress {
 	    	$query->view($a["view"]);
 
 	    if (isset($a["sort"]))
-	    	$query->view($a["sort"]);
+	    	$query->sort($a["sort"]);
 
 	    if (isset($a["maxrecords"]))
 	    	$query->maxRecords($a["maxrecords"]);


### PR DESCRIPTION
Setting the sort property on shortcodes did not work, since it called the wrong method.