### PR TITLE
Add sort options for overview pages

### DIFF
--- a/lib/chetmac/AirpressVirtualPosts.php
+++ b/lib/chetmac/AirpressVirtualPosts.php
@@ -145,6 +145,11 @@ class AirpressVirtualPosts {
 
 			$query->filterByFormula($formula);
 
+			// Handle sort parameter
+			if (isset($this->config["sort"]) && !empty($this->config["sort"])){
+				$query->sort($this->config["sort"]);
+			}
+
 			if ( $simulation ){
 				$query->fields(array()); // specify no fields so this is as quick as possible
 			} else {

--- a/lib/chetmac/AirpressVirtualPostsAdmin.php
+++ b/lib/chetmac/AirpressVirtualPostsAdmin.php
@@ -114,6 +114,7 @@ function airpress_admin_vp_tab($key,$config) {
 		"pattern"		=> "^folder/(.*)",
 		"default"		=> "folder/my-unique-identifier",
 		"formula"		=> "{Your Airtable Field} = '$1'",
+		"sort"			=> "Your Airtable Field",
 		"table"			=> "Your Airtable Table",
 		"field"			=> "Your Airtable Field",
 		"field2"		=> "Your Airtable Field2",
@@ -171,6 +172,11 @@ function airpress_admin_vp_tab($key,$config) {
 	################################
 	$field_name = "formula";
 	$field_title = "Filter by formula";
+	add_settings_field(	$field_name, __( $field_title, 'airpress' ), 'airpress_admin_vp_render_element_text', $option_name, $section_name, array($options,$option_name,$field_name) );
+
+	################################
+	$field_name = "sort";
+	$field_title = "Sort results";
 	add_settings_field(	$field_name, __( $field_title, 'airpress' ), 'airpress_admin_vp_render_element_text', $option_name, $section_name, array($options,$option_name,$field_name) );
 
 	################################


### PR DESCRIPTION
This allows you to sort on pages that do not have a filter set, getting all results from a table.